### PR TITLE
fix #2 Add Rails 5.1 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ pgcli-rails is in a pre-1.0 state. This means that its APIs and behavior are sub
 ## [Unreleased][]
 
 * Your contribution here!
+* [#3](https://github.com/mattbrictson/pgcli-rails/pull/3): Add Rails 5.1 support - [@nachokb](https://github.com/nachokb)
 
 ## [0.2.1][] (2016-07-18)
 

--- a/lib/pgcli/rails/dbconsole.rb
+++ b/lib/pgcli/rails/dbconsole.rb
@@ -1,4 +1,8 @@
-require "rails/commands/dbconsole"
+begin
+  require "rails/commands/dbconsole"
+rescue LoadError
+  require "rails/commands/dbconsole/dbconsole_command"
+end
 
 module Pgcli
   module Rails

--- a/lib/pgcli/rails/tasks.rake
+++ b/lib/pgcli/rails/tasks.rake
@@ -5,6 +5,12 @@ task :pgcli do
   # APP_PATH constant must be set for DBConsole to work
   APP_PATH = Rails.root.join("config", "application") unless defined?(APP_PATH)
 
-  console = Pgcli::Rails::DBConsole.new(["--include-password"])
+  opt = if ::Rails.version >= "5.1"
+          { "--include-password" => true }
+        else
+          ["--include-password"]
+        end
+
+  console = Pgcli::Rails::DBConsole.new(opt)
   console.start
 end


### PR DESCRIPTION
# Defect

`pgcli-rails` does not support Rails 5.1

# Cause

* Rails project moved the `rails/commands/dbconsole` file to `rails/commands/dbconsole/dbconsole_command`;
* `Rails::DBConsole` initializer no accepts a Hash instead of an Array;

# Solution

* Add support for the new changes without breaking the older versions;

# References

* [in this commit Rails removed the old commands structure](03c982fa3417fc49a380eeb88fdd26fdd4bae46b)