### PR TITLE
Adopt latest Gemfile and .gemspec standards

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+require:
+  - rubocop-packaging
+
 AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,8 @@
 source "https://rubygems.org"
-
-# Specify your gem's dependencies in pgcli-rails.gemspec
 gemspec
+
+gem "minitest", "~> 5.0"
+gem "minitest-reporters", "~> 1.1"
+gem "rake", "~> 13.0"
+gem "rubocop", "0.92.0"
+gem "rubocop-packaging", "0.5.0"

--- a/pgcli-rails.gemspec
+++ b/pgcli-rails.gemspec
@@ -1,29 +1,28 @@
-lib = File.expand_path("lib", __dir__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "pgcli/rails/version"
+require_relative "lib/pgcli/rails/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "pgcli-rails"
-  spec.version       = Pgcli::Rails::VERSION
-  spec.authors       = ["Matt Brictson"]
-  spec.email         = ["opensource@mattbrictson.com"]
+  spec.name = "pgcli-rails"
+  spec.version = Pgcli::Rails::VERSION
+  spec.authors = ["Matt Brictson"]
+  spec.email = ["opensource@mattbrictson.com"]
 
-  spec.summary       = "Replaces the Rails PostgreSQL dbconsole with the much nicer pgcli"
-  spec.homepage      = "https://github.com/mattbrictson/pgcli-rails"
-  spec.license       = "MIT"
+  spec.summary = "Replaces the Rails PostgreSQL dbconsole with the much nicer pgcli"
+  spec.homepage = "https://github.com/mattbrictson/pgcli-rails"
+  spec.license = "MIT"
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.metadata = {
+    "bug_tracker_uri" => "https://github.com/mattbrictson/pgcli-rails/issues",
+    "changelog_uri" => "https://github.com/mattbrictson/pgcli-rails/releases",
+    "source_code_uri" => "https://github.com/mattbrictson/pgcli-rails",
+    "homepage_uri" => spec.homepage
+  }
+
+  # Specify which files should be added to the gem when it is released.
+  spec.files = Dir.glob(%w[LICENSE.txt README.md {exe,lib}/**/*]).reject { |f| File.directory?(f) }
+  spec.bindir = "exe"
+  spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.5.0"
-
   spec.add_dependency "railties", ">= 4.2.0"
-
-  spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "minitest", "~> 5.0"
-  spec.add_development_dependency "minitest-reporters", "~> 1.1"
-  spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "rubocop", "0.92.0"
 end


### PR DESCRIPTION
- Place development dependencies in the `Gemfile`, not the `.gemspec`
- Do not modify the `$LOAD_PATH` in the `.gemspec`
- Use `Gem::Requirement.new` to specify Ruby requirement
- Do not include `bundler` as a development dependency
- Do not shell out to `git` when gemspec is evaluated
- Add rubocop-packaging gem