### PR TITLE
Drop support for Ruby 2.6 and Ruby 2.7 (EOL)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
   NewCops: enable
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 3.0
   Exclude:
     - "tmp/**/*"
     - "vendor/**/*"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -13,7 +13,7 @@ global_job_config:
   prologue:
     commands:
       - checkout
-      - export SEM_RUBY=${SEM_RUBY:-3.2.0}
+      - export SEM_RUBY=${SEM_RUBY:-3.2.2}
       - sem-version ruby $SEM_RUBY
       - cache restore "gems-${SEM_RUBY}-${SEMAPHORE_GIT_WORKING_BRANCH}-,gems-${SEM_RUBY}-main-"
       - bundle check || bundle install
@@ -33,7 +33,7 @@ blocks:
         - name: Test
           matrix:
             - env_var: SEM_RUBY
-              values: ["2.6.10", "2.7.7", "3.0.5", "3.1.3", "3.2.0"]
+              values: ["3.0.6", "3.1.4", "3.2.2"]
           commands:
             - bundle exec rake test TESTOPTS="--ci-dir=./reports"
             - test-results publish ./reports

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ RAILS_ENV=test bin/rake pgcli
 ## Requirements
 
 * Rails 4.2+ using PostgreSQL
-* Ruby 2.6+
+* Ruby 3.0+
 * [pgcli][] (`brew install pgcli` to install on macOS)
 
 ## How it works

--- a/Rakefile
+++ b/Rakefile
@@ -105,7 +105,7 @@ module RubyVersions
     end
 
     def latest_supported_patches
-      patches = versions.values_at(:stable, :security_maintenance, :eol).compact.flatten
+      patches = versions.values_at(:stable, :security_maintenance).compact.flatten
       patches.map { |p| Gem::Version.new(p) }.sort.map(&:to_s)
     end
 

--- a/pgcli-rails.gemspec
+++ b/pgcli-rails.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.summary = "Replaces the Rails PostgreSQL dbconsole with the much nicer pgcli"
   spec.homepage = "https://github.com/mattbrictson/pgcli-rails"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.6"
+  spec.required_ruby_version = ">= 3.0"
 
   spec.metadata = {
     "bug_tracker_uri" => "https://github.com/mattbrictson/pgcli-rails/issues",

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,4 +2,4 @@ $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "pgcli/rails"
 
 require "minitest/autorun"
-Dir[File.expand_path("support/**/*.rb", __dir__)].sort.each { |rb| require(rb) }
+Dir[File.expand_path("support/**/*.rb", __dir__)].each { |rb| require(rb) }


### PR DESCRIPTION
Also update the CI matrix to include the latest Ruby patch releases: 3.0.6, 3.1.4, and 3.2.2.