### PR TITLE
Simplify test dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "minitest", "~> 5.0"
-gem "minitest-reporters", "~> 1.1"
+gem "minitest-rg", "~> 5.3"
 gem "rake", "~> 13.0"
 gem "rubocop", "1.58.0"
 gem "rubocop-minitest", "0.33.0"

--- a/test/support/reporters.rb
+++ b/test/support/reporters.rb
@@ -1,7 +1,0 @@
-require "minitest/reporters"
-
-if ENV["CI"]
-  Minitest::Reporters.use!(Minitest::Reporters::SpecReporter.new)
-else
-  Minitest::Reporters.use!(Minitest::Reporters::DefaultReporter.new)
-end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,4 +2,4 @@ $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "pgcli/rails"
 
 require "minitest/autorun"
-Dir[File.expand_path("support/**/*.rb", __dir__)].each { |rb| require(rb) }
+require "minitest/rg"


### PR DESCRIPTION
- Remove `minitest-reporters` in favor of `minitest-rg`, which is simpler, is officially maintained by the minitest GitHub organization, and doesn't patch minitest internals in ways that can break other plugins
- Remove now unneeded `test/support` directory